### PR TITLE
fix(apigateway): fix path variable name

### DIFF
--- a/resources/dynamodb-votes-table.yml
+++ b/resources/dynamodb-votes-table.yml
@@ -44,7 +44,9 @@ Resources:
 Outputs:
   VotesTableArn:
     Value:
-      "Fn::GetAtt": [ VotesTable, Arn ]
+      Fn::GetAtt: [ VotesTable, Arn ]
   VotesTableStreamArn:
     Value:
-      "Fn::GetAtt": [ VotesTable, StreamArn ]
+      Fn::GetAtt: [ VotesTable, StreamArn ]
+    Export:
+      Name: VotesTableStreamArn

--- a/serverless.yml
+++ b/serverless.yml
@@ -66,7 +66,7 @@ functions:
     events:
       - http:
           method: get
-          path: meetings/{id}
+          path: meetings/{meetingId}
           cors: true
           authorizer:
             type: COGNITO_USER_POOLS
@@ -92,7 +92,7 @@ functions:
     events:
       - http:
           method: delete
-          path: meetings/{id}
+          path: meetings/{meetingId}
           cors: true
           authorizer:
             type: COGNITO_USER_POOLS
@@ -105,7 +105,7 @@ functions:
     events:
       - http:
           method: patch
-          path: meetings/{id}
+          path: meetings/{meetingId}
           cors: true
           authorizer:
             type: COGNITO_USER_POOLS
@@ -118,7 +118,7 @@ functions:
     events:
       - http:
           method: get
-          path: meetings/{id}/questions
+          path: meetings/{meetingId}/questions
           cors: true
           authorizer:
             type: COGNITO_USER_POOLS
@@ -145,7 +145,7 @@ functions:
           enabled: true
           type: dynamodb
           arn:
-            'Fn::GetAtt': [VotesTable, LatestStreamArn]
+            Fn::ImportValue: VotesTableStreamArn
           batchSize: 10
           startingPosition: LATEST
   # Vote endpoints

--- a/src/meeting/controller.ts
+++ b/src/meeting/controller.ts
@@ -5,8 +5,8 @@ import { Meeting, MeetingBody } from './Meeting';
 import { createProxyResult } from '../util';
 
 export const getMeeting: APIGatewayProxyHandler = async (event) => {
-  const id = event.pathParameters!.id as Meeting['id'];
-  const meeting = await MeetingService.getMeeting(id);
+  const meetingId = event.pathParameters!.meetingId as Meeting['id'];
+  const meeting = await MeetingService.getMeeting(meetingId);
 
   return createProxyResult(HttpStatus.OK, meeting);
 };
@@ -19,23 +19,23 @@ export const createMeeting: APIGatewayProxyHandler = async (event) => {
 };
 
 export const deleteMeeting: APIGatewayProxyHandler = async (event) => {
-  const id = event.pathParameters!.id as Meeting['id'];
-  await MeetingService.deleteMeeting(id);
+  const meetingId = event.pathParameters!.meetingId as Meeting['id'];
+  await MeetingService.deleteMeeting(meetingId);
 
   return createProxyResult(HttpStatus.NO_CONTENT, {});
 };
 
 export const updateMeeting: APIGatewayProxyHandler = async (event) => {
-  const id = event.pathParameters!.id as Meeting['id'];
+  const meetingId = event.pathParameters!.meetingId as Meeting['id'];
   const meeting = JSON.parse(event.body!) as Partial<MeetingBody>;
-  await MeetingService.updateMeeting(id, meeting);
+  await MeetingService.updateMeeting(meetingId, meeting);
 
   return createProxyResult(HttpStatus.NO_CONTENT, {});
 };
 
 export const getQuestionsOfMeeting: APIGatewayProxyHandler = async (event) => {
-  const id = event.pathParameters!.id as Meeting['id'];
-  const questions = await MeetingService.getQuestionsOfMeeting(id);
+  const meetingId = event.pathParameters!.meetingId as Meeting['id'];
+  const questions = await MeetingService.getQuestionsOfMeeting(meetingId);
 
   return createProxyResult(HttpStatus.OK, questions);
 };

--- a/src/meeting/repository.ts
+++ b/src/meeting/repository.ts
@@ -5,10 +5,10 @@ import { NotFoundException } from '../error/not-found-exception';
 import { generateSetExpressions } from '../util';
 const TableName = `${process.env.MEETINGS_TABLE}-${process.env.NODE_ENV}`;
 
-export const getMeeting = async (id: Meeting['id']): Promise<Meeting | undefined> => {
+export const getMeeting = async (meetingId: Meeting['id']): Promise<Meeting | undefined> => {
   const params = {
     TableName,
-    Key: { id },
+    Key: { id: meetingId },
   };
   const { Item: meeting } = await docClient.get(params).promise();
 
@@ -16,9 +16,9 @@ export const getMeeting = async (id: Meeting['id']): Promise<Meeting | undefined
 };
 
 export const createMeeting = async (meeting: MeetingBody): Promise<Pick<Meeting, 'id'>> => {
-  const id = uuidv4();
+  const meetingId = uuidv4();
   const meetingDocument = {
-    id,
+    id: meetingId,
     status: MeetingStatus.Open,
     ...meeting,
   } as Meeting;
@@ -29,14 +29,14 @@ export const createMeeting = async (meeting: MeetingBody): Promise<Pick<Meeting,
 
   await docClient.put(params).promise();
 
-  return { id };
+  return { id: meetingId };
 };
 
-export const deleteMeeting = async (id: Meeting['id']): Promise<void> => {
+export const deleteMeeting = async (meetingId: Meeting['id']): Promise<void> => {
   try {
     const params = {
       TableName,
-      Key: { id },
+      Key: { id: meetingId },
       ConditionExpression: 'attribute_exists(id) AND #status <> :status',
       UpdateExpression: 'SET #status = :status',
       ExpressionAttributeNames: {
@@ -54,7 +54,7 @@ export const deleteMeeting = async (id: Meeting['id']): Promise<void> => {
 };
 
 export const updateMeeting = async (
-  id: Meeting['id'],
+  meetingId: Meeting['id'],
   meeting: Partial<MeetingBody>
 ): Promise<void> => {
   try {
@@ -65,7 +65,7 @@ export const updateMeeting = async (
     } = generateSetExpressions(meeting);
     const params = {
       TableName,
-      Key: { id },
+      Key: { id: meetingId },
       ConditionExpression: 'attribute_exists(id) AND #status <> :status',
       UpdateExpression,
       ExpressionAttributeNames: {

--- a/src/meeting/schema.ts
+++ b/src/meeting/schema.ts
@@ -4,7 +4,7 @@ import { validator } from '../middleware/validator';
 const getMeetingSchema = Joi.object()
   .keys({
     pathParameters: Joi.object().keys({
-      id: Joi.string().guid({ version: 'uuidv4' }).required(),
+      meetingId: Joi.string().guid({ version: 'uuidv4' }).required(),
     }),
   })
   .unknown();
@@ -29,7 +29,7 @@ const createMeetingSchema = Joi.object()
 const deleteMeetingSchema = Joi.object()
   .keys({
     pathParameters: Joi.object().keys({
-      id: Joi.string().guid({ version: 'uuidv4' }).required(),
+      meetingId: Joi.string().guid({ version: 'uuidv4' }).required(),
     }),
   })
   .unknown();
@@ -37,7 +37,7 @@ const deleteMeetingSchema = Joi.object()
 const updateMeetingSchema = Joi.object()
   .keys({
     pathParameters: Joi.object().keys({
-      id: Joi.string().guid({ version: 'uuidv4' }).required(),
+      meetingId: Joi.string().guid({ version: 'uuidv4' }).required(),
     }),
     body: Joi.object().keys({
       title: Joi.string(),
@@ -57,7 +57,7 @@ const updateMeetingSchema = Joi.object()
 const getQuestionsOfMeetingSchema = Joi.object()
   .keys({
     pathParameters: Joi.object().keys({
-      id: Joi.string().guid({ version: 'uuidv4' }).required(),
+      meetingId: Joi.string().guid({ version: 'uuidv4' }).required(),
     }),
   })
   .unknown();

--- a/src/meeting/service.ts
+++ b/src/meeting/service.ts
@@ -5,8 +5,8 @@ import { GetQuestionsOfMeetingResponse } from '../question/Question';
 import { Meeting, MeetingBody, MeetingStatus } from './Meeting';
 import * as MeetingRepository from './repository';
 
-export const getMeeting = async (id: Meeting['id']): Promise<Meeting> => {
-  const meeting = await MeetingRepository.getMeeting(id);
+export const getMeeting = async (meetingId: Meeting['id']): Promise<Meeting> => {
+  const meeting = await MeetingRepository.getMeeting(meetingId);
 
   if (!meeting || meeting.status === MeetingStatus.Deleted) {
     throw new NotFoundException();
@@ -19,25 +19,25 @@ export const createMeeting = (meeting: MeetingBody): Promise<Pick<Meeting, 'id'>
   return MeetingRepository.createMeeting(meeting);
 };
 
-export const deleteMeeting = async (id: Meeting['id']): Promise<void> => {
-  return MeetingRepository.deleteMeeting(id);
+export const deleteMeeting = async (meetingId: Meeting['id']): Promise<void> => {
+  return MeetingRepository.deleteMeeting(meetingId);
 };
 
 export const updateMeeting = async (
-  id: Meeting['id'],
+  meetingId: Meeting['id'],
   meeting: Partial<MeetingBody>
 ): Promise<void> => {
-  return MeetingRepository.updateMeeting(id, meeting);
+  return MeetingRepository.updateMeeting(meetingId, meeting);
 };
 
 export const getQuestionsOfMeeting = async (
-  id: Meeting['id']
+  meetingId: Meeting['id']
 ): Promise<GetQuestionsOfMeetingResponse> => {
-  return QuestionService.getQuestionsOfMeeting(id);
+  return QuestionService.getQuestionsOfMeeting(meetingId);
 };
 
-export const getOpenMeeting = async (id: Meeting['id']): Promise<Meeting> => {
-  const meeting = await MeetingRepository.getMeeting(id);
+export const getOpenMeeting = async (meetingId: Meeting['id']): Promise<Meeting> => {
+  const meeting = await MeetingRepository.getMeeting(meetingId);
 
   if (!meeting || meeting.status === MeetingStatus.Deleted) {
     throw new NotFoundException();

--- a/src/question/service.ts
+++ b/src/question/service.ts
@@ -6,8 +6,8 @@ import { GetQuestionsOfMeetingResponse, Question, QuestionBodyWithUserId } from 
 import * as QuestionRepository from './repository';
 import { VoteType } from '../vote/Vote';
 
-export const getQuestion = async (id: Question['id']): Promise<Question> => {
-  const question = await QuestionRepository.getQuestion(id);
+export const getQuestion = async (questionId: Question['id']): Promise<Question> => {
+  const question = await QuestionRepository.getQuestion(questionId);
 
   if (!question) {
     throw new NotFoundException();
@@ -16,7 +16,7 @@ export const getQuestion = async (id: Question['id']): Promise<Question> => {
   return question;
 };
 
-export const createQuestion = (question: QuestionBodyWithUserId): Promise<Question> => {
+export const createQuestion = (question: QuestionBodyWithUserId): Promise<Pick<Question, 'id'>> => {
   return QuestionRepository.createQuestion(question);
 };
 


### PR DESCRIPTION
API Gateway doesn't allow more than one path variable name under the same resource. In this case, we had both {{id}} and {{meetingId}} under the /meeting so I changed the {{id}} to {{meetingId}} as well. Also, we should avoid using only `id` in our code too since it doesn't specify which entity it belongs to.